### PR TITLE
Add ephemeral key generation and split rekey into API

### DIFF
--- a/nkms/crypto/_internal.py
+++ b/nkms/crypto/_internal.py
@@ -1,0 +1,16 @@
+from nkms.crypto import api as API
+from typing import Tuple, Union
+from npre import elliptic_curve
+
+
+def _ecies_gen_ephemeral_key(
+        recp_pubkey: Union[bytes, elliptic_curve.ec_element]
+) -> Tuple[bytes, bytes]:
+    """
+    Generates and encrypts an ephemeral key for the `recp_pubkey`.
+
+    :param recp_pubkey: Recipient's pubkey
+
+    :return: Tuple of encrypted symmetric key, and encrypted ephemeral privkey
+    """
+    pass

--- a/nkms/crypto/_internal.py
+++ b/nkms/crypto/_internal.py
@@ -5,12 +5,17 @@ from npre import elliptic_curve
 
 def _ecies_gen_ephemeral_key(
         recp_pubkey: Union[bytes, elliptic_curve.ec_element]
-) -> Tuple[bytes, bytes]:
+) -> Tuple[bytes, Tuple[bytes, bytes]]:
     """
     Generates and encrypts an ephemeral key for the `recp_pubkey`.
 
     :param recp_pubkey: Recipient's pubkey
 
-    :return: Tuple of encrypted symmetric key, and encrypted ephemeral privkey
+    :return: Tuple of the eph_privkey, and a tuple of the encrypted symmetric
+             key, and encrypted ephemeral privkey
     """
-    pass
+    symm_key, enc_symm_key = API.ecies_encapsulate(recp_pubkey)
+    eph_privkey = API.ecies_gen_priv()
+
+    enc_eph_privkey = API.symm_encrypt(symm_key, eph_privkey)
+    return (eph_privkey, (enc_symm_key, enc_eph_privkey))

--- a/nkms/crypto/api.py
+++ b/nkms/crypto/api.py
@@ -4,6 +4,7 @@ from typing import Tuple, Union, List
 import sha3
 from nacl.secret import SecretBox
 from py_ecc.secp256k1 import N, privtopub, ecdsa_raw_recover, ecdsa_raw_sign
+from nkms.crypto import _internal
 
 from npre import elliptic_curve
 from npre import umbral
@@ -398,9 +399,12 @@ def ecies_ephemeral_split_rekey(
     :param total_shares: Total shares to generate from split-rekey gen
 
     :return: A tuple containing a list of rekey frags, and a tuple of the
-             encrypted ephemeral key data
+             encrypted ephemeral key data (enc_symm_key, enc_eph_privkey)
     """
-    pass
+    eph_privkey, enc_eph_data = _internal._ecies_gen_ephemeral_key(pubkey_b)
+    frags = ecies_split_rekey(privkey_a, eph_privkey, min_shares, total_shares)
+
+    return (frags, enc_eph_data)
 
 
 def ecies_combine(

--- a/nkms/crypto/api.py
+++ b/nkms/crypto/api.py
@@ -380,6 +380,29 @@ def ecies_split_rekey(
                            min_shares, total_shares)
 
 
+def ecies_ephemeral_split_rekey(
+        privkey_a: Union[bytes, elliptic_curve.ec_element],
+        pubkey_b: Union[bytes, elliptic_curve.ec_element],
+        min_shares: int,
+        total_shares: int
+) -> Tuple[List[umbral.RekeyFrag], Tuple[bytes, bytes]]:
+    """
+    Performs a split-key re-encryption key generation where a minimum
+    number of shares `min_shares` are required to reproduce a rekey.
+    Will split a rekey inot `total_shares`.
+    This also generates an ephemeral keypair for the recipient as `pubkey_b`.
+
+    :param privkey_a: Privkey to re-encrypt from
+    :param pubkey_b: Public key to re-encrypt for (w/ ephemeral key)
+    :param min_shares: Minium shares needed to reproduce a rekey
+    :param total_shares: Total shares to generate from split-rekey gen
+
+    :return: A tuple containing a list of rekey frags, and a tuple of the
+             encrypted ephemeral key data
+    """
+    pass
+
+
 def ecies_combine(
         encrypted_keys: List[umbral.EncryptedKey]
 ) -> umbral.EncryptedKey:

--- a/tests/crypto/test_api.py
+++ b/tests/crypto/test_api.py
@@ -281,6 +281,18 @@ class TestCrypto(unittest.TestCase):
         self.assertEqual(list, type(frags))
         self.assertEqual(4, len(frags))
 
+    def test_ecies_ephemeral_split_rekey(self):
+        frags, enc_eph_data = api.ecies_ephemeral_split_rekey(self.privkey_a,
+                                                              self.pubkey_b,
+                                                              3, 4)
+        self.assertEqual(list, type(frags))
+        self.assertEqual(4, len(frags))
+
+        self.assertEqual(tuple, type(enc_eph_data))
+        self.assertEqual(2, len(enc_eph_data))
+        self.assertEqual(umbral.EncryptedKey, type(enc_eph_data[0]))
+        self.assertEqual(EncryptedMessage, type(enc_eph_data[1]))
+
     def test_ecies_combine(self):
         eph_priv = self.pre.gen_priv()
         eph_pub = self.pre.priv2pub(eph_priv)

--- a/tests/crypto/test_internal.py
+++ b/tests/crypto/test_internal.py
@@ -1,0 +1,53 @@
+import unittest
+from nacl.utils import EncryptedMessage
+from nkms.crypto import _internal
+from nkms.crypto import api
+from npre import elliptic_curve as ec
+from npre import umbral
+
+
+class TestInternal(unittest.TestCase):
+    def setUp(self):
+        self.pre = umbral.PRE()
+        self.privkey_a = self.pre.gen_priv()
+        self.privkey_a_bytes = ec.serialize(self.privkey_a)[1:]
+
+        self.privkey_b = self.pre.gen_priv()
+        self.privkey_b_bytes = ec.serialize(self.privkey_b)[1:]
+
+        self.pubkey_a = self.pre.priv2pub(self.privkey_a)
+        self.pubkey_b = self.pre.priv2pub(self.privkey_b)
+
+        self.pubkey_a_bytes = ec.serialize(self.pubkey_a)[1:]
+        self.pubkey_b_bytes = ec.serialize(self.pubkey_b)[1:]
+
+    def test_ecies_gen_ephemeral_key(self):
+        result_data = _internal._ecies_gen_ephemeral_key(
+                                            self.pubkey_a)
+        self.assertEqual(tuple, type(result_data))
+        self.assertEqual(2, len(result_data))
+
+        eph_privkey, enc_data = result_data
+
+        self.assertEqual(bytes, type(eph_privkey))
+        self.assertEqual(32, len(eph_privkey))
+
+        self.assertEqual(tuple, type(enc_data))
+        self.assertEqual(2, len(enc_data))
+
+        enc_symm_key, enc_eph_key = enc_data
+
+        self.assertEqual(umbral.EncryptedKey, type(enc_symm_key))
+        self.assertEqual(EncryptedMessage, type(enc_eph_key))
+        self.assertNotEqual(eph_privkey, enc_eph_key)
+
+        dec_symm_key = api.ecies_decapsulate(self.privkey_a, enc_symm_key)
+
+        self.assertEqual(bytes, type(dec_symm_key))
+        self.assertEqual(32, len(dec_symm_key))
+
+        dec_eph_key = api.symm_decrypt(dec_symm_key, enc_eph_key)
+
+        self.assertEqual(bytes, type(dec_eph_key))
+        self.assertEqual(32, len(dec_eph_key))
+        self.assertEqual(eph_privkey, dec_eph_key)


### PR DESCRIPTION
1. Adds an `ecies_ephemeral_split_rekey` function to `nkms.crypto.api`.
    1. Creates an `_internal.py` file to house internal crypto api functions.
        1. Adds a `_ecies_gen_ephemeral_key` function to the `_internal` module.
2. Adds tests for the above changes.